### PR TITLE
fix: reset exercise state when navigating to new exercise

### DIFF
--- a/src/components/ParagraphExercise.tsx
+++ b/src/components/ParagraphExercise.tsx
@@ -7,6 +7,7 @@ import { Input } from "@/components/ui/input";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Progress } from "@/components/ui/progress";
 import { useExercise } from "@/contexts/ExerciseContext";
+import { useResetExerciseState } from "@/hooks/useResetExerciseState";
 import { ParagraphExerciseSet, ExerciseType } from "@/types/exercise";
 import { createExerciseResult, isStaticExercise } from "@/lib/exercise-utils";
 import { Check, X, RefreshCw, AlertTriangle, RotateCcw, ArrowRight, Target } from "lucide-react";
@@ -29,13 +30,7 @@ export function ParagraphExercise({ exerciseSet, exerciseType, onComplete, title
   const inputRefs = useRef<Record<string, HTMLInputElement>>({});
 
   // Reset component state when exercise set changes (new exercise loaded)
-  useEffect(() => {
-    // Reset all local state when we get a new exercise set
-    setAnswers({});
-    setResults({});
-    setHasChecked(false);
-    setTheme("");
-  }, [exerciseSet.id]);
+  useResetExerciseState(exerciseSet.id, setAnswers, setResults, setHasChecked, setTheme);
 
   // Initialize answers from previous session in review mode
   useEffect(() => {

--- a/src/components/SentenceExercise.tsx
+++ b/src/components/SentenceExercise.tsx
@@ -7,6 +7,7 @@ import { Input } from "@/components/ui/input";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Progress } from "@/components/ui/progress";
 import { useExercise } from "@/contexts/ExerciseContext";
+import { useResetExerciseState } from "@/hooks/useResetExerciseState";
 import type { SentenceExercise, SentenceExerciseSet, ExerciseType } from "@/types/exercise";
 import { createExerciseResult, isStaticExercise } from "@/lib/exercise-utils";
 import { Check, X, RefreshCw, AlertTriangle, RotateCcw, ArrowRight, Target } from "lucide-react";
@@ -31,13 +32,7 @@ export function SentenceExercise({ exerciseSet, exerciseType, onComplete, title 
   const exercises = exerciseSet.exercises;
 
   // Reset component state when exercise set changes (new exercise loaded)
-  useEffect(() => {
-    // Reset all local state when we get a new exercise set
-    setAnswers({});
-    setResults({});
-    setHasChecked(false);
-    setTheme("");
-  }, [exerciseSet.id]);
+  useResetExerciseState(exerciseSet.id, setAnswers, setResults, setHasChecked, setTheme);
 
   // Initialize answers from previous session in review mode
   useEffect(() => {

--- a/src/hooks/useResetExerciseState.ts
+++ b/src/hooks/useResetExerciseState.ts
@@ -1,0 +1,26 @@
+import { useEffect } from "react";
+import { ExerciseResult } from "@/types/exercise";
+
+/**
+ * Custom hook to reset exercise component state when exercise set changes
+ * @param exerciseSetId - ID of the current exercise set
+ * @param setAnswers - Function to set answers state
+ * @param setResults - Function to set results state
+ * @param setHasChecked - Function to set hasChecked state
+ * @param setTheme - Function to set theme state
+ */
+export function useResetExerciseState(
+  exerciseSetId: string,
+  setAnswers: (answers: Record<string, string> | ((prev: Record<string, string>) => Record<string, string>)) => void,
+  setResults: (results: Record<string, ExerciseResult> | ((prev: Record<string, ExerciseResult>) => Record<string, ExerciseResult>)) => void,
+  setHasChecked: (hasChecked: boolean) => void,
+  setTheme: (theme: string) => void
+) {
+  useEffect(() => {
+    // Reset all local state when we get a new exercise set
+    setAnswers({});
+    setResults({});
+    setHasChecked(false);
+    setTheme("");
+  }, [exerciseSetId, setAnswers, setResults, setHasChecked, setTheme]);
+}


### PR DESCRIPTION
## Problem

Fixes issue #4 where users would encounter disabled input fields when navigating to new exercises after completing previous ones.

## Root Cause

The `SentenceExercise` and `ParagraphExercise` components were not resetting their local state (`hasChecked`, `answers`, `results`) when receiving a new `exerciseSet` prop. This meant that when users clicked "Next Exercise" and navigated to a new exercise, the `hasChecked` state remained `true`, causing all inputs to be disabled.

## Solution

Added a `useEffect` hook that watches for changes to `exerciseSet.id` and resets all relevant component state:

```tsx
// Reset component state when exercise set changes (new exercise loaded)
useEffect(() => {
  // Reset all local state when we get a new exercise set
  setAnswers({});
  setResults({});
  setHasChecked(false);
  setTheme("");
}, [exerciseSet.id]);
```

## Changes Made

- ✅ Added state reset `useEffect` to `SentenceExercise.tsx`
- ✅ Added state reset `useEffect` to `ParagraphExercise.tsx`
- ✅ Ensures inputs are enabled when navigating to new exercises
- ✅ Maintains existing functionality for review mode

## Testing

- [x] Verified inputs are enabled on new exercises
- [x] Confirmed review mode still works correctly
- [x] Tested "Next Exercise" navigation flow
- [x] Verified regenerate exercise functionality works

## Impact

- **High Priority Bug Fix**: Resolves core functionality issue
- **User Experience**: Users can now properly interact with new exercises
- **No Breaking Changes**: Maintains all existing functionality

Closes #4