### PR TITLE
feat: add loading feedback for next exercise button

### DIFF
--- a/src/components/ResultsDisplay.tsx
+++ b/src/components/ResultsDisplay.tsx
@@ -5,7 +5,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Progress } from "@/components/ui/progress";
 import { useExercise } from "@/contexts/ExerciseContext";
 import { calculateScore } from "@/lib/exercise-utils";
-import { RotateCcw, Target, TrendingUp, Award, AlertTriangle, ArrowRight } from "lucide-react";
+import { RotateCcw, Target, TrendingUp, Award, AlertTriangle, ArrowRight, RefreshCw } from "lucide-react";
 
 interface ResultsDisplayProps {
   onRestart: () => void;
@@ -25,6 +25,7 @@ export function ResultsDisplay({ onRestart, onReviewMistakes, onNextExercise }: 
   const diacriticWarnings = state.currentSession.results.filter((r) => r.correct && r.diacriticWarning);
   const hasMistakes = mistakes.length > 0;
   const hasDiacriticWarnings = diacriticWarnings.length > 0;
+  const isGenerating = state.isGenerating;
 
   // Get the current exercise data to extract the exercise ID
   const getCurrentExerciseData = () => {
@@ -129,20 +130,29 @@ export function ResultsDisplay({ onRestart, onReviewMistakes, onNextExercise }: 
           </div>
 
           <div className="flex flex-col sm:flex-row gap-2 justify-center">
-            <Button onClick={onRestart} size="lg" variant="outline">
+            <Button onClick={onRestart} size="lg" variant="outline" disabled={isGenerating}>
               <RotateCcw className="h-4 w-4 mr-2" />
               Try Again
             </Button>
 
             {onNextExercise && (
-              <Button onClick={handleNextExercise} size="lg" variant="default">
-                <ArrowRight className="h-4 w-4 mr-2" />
-                Next Exercise
+              <Button onClick={handleNextExercise} size="lg" variant="default" disabled={isGenerating}>
+                {isGenerating ? (
+                  <>
+                    <RefreshCw className="h-4 w-4 mr-2 animate-spin" />
+                    Generating...
+                  </>
+                ) : (
+                  <>
+                    <ArrowRight className="h-4 w-4 mr-2" />
+                    Next Exercise
+                  </>
+                )}
               </Button>
             )}
 
             {hasMistakes && (
-              <Button variant="outline" onClick={onReviewMistakes} size="lg">
+              <Button variant="outline" onClick={onReviewMistakes} size="lg" disabled={isGenerating}>
                 <Target className="h-4 w-4 mr-2" />
                 Review Mistakes ({mistakes.length})
               </Button>


### PR DESCRIPTION
## Problem

Fixes #7

When users click "Next Exercise" after completing an exercise, there's a significant delay while a new exercise is being generated, but no loading feedback is provided. This creates a poor user experience as users are left wondering if their click registered or if the app is frozen.

## Solution

Added immediate visual feedback when "Next Exercise" button is clicked:

- **Loading spinner**: Shows animated RefreshCw icon during generation
- **Text feedback**: Button text changes to "Generating..." 
- **Button state management**: All action buttons are disabled during generation to prevent multiple clicks
- **Consistent UX**: Uses existing `isGenerating` state from ExerciseContext

## Changes Made

- ✅ Added `RefreshCw` import from lucide-react for loading spinner
- ✅ Added `isGenerating` state extraction from ExerciseContext
- ✅ Updated "Next Exercise" button with conditional rendering:
  - Shows spinner + "Generating..." when `isGenerating` is true
  - Shows arrow + "Next Exercise" when `isGenerating` is false
- ✅ Disabled all buttons during generation (Try Again, Next Exercise, Review Mistakes)

## Technical Implementation

```tsx
{onNextExercise && (
  <Button onClick={handleNextExercise} size="lg" variant="default" disabled={isGenerating}>
    {isGenerating ? (
      <>
        <RefreshCw className="h-4 w-4 mr-2 animate-spin" />
        Generating...
      </>
    ) : (
      <>
        <ArrowRight className="h-4 w-4 mr-2" />
        Next Exercise
      </>
    )}
  </Button>
)}
```

## Impact

- **Immediate feedback**: Users know their click registered and generation is in progress
- **Better UX**: No more wondering if the app is frozen or unresponsive
- **Prevents multiple clicks**: Disabled state prevents accidental duplicate requests
- **Consistent behavior**: Matches loading patterns already used in exercise regeneration buttons

## Testing

- [x] Verified loading state appears immediately when "Next Exercise" is clicked
- [x] Confirmed button shows spinner and "Generating..." text
- [x] Tested that all buttons are properly disabled during generation
- [x] Verified button returns to normal state after generation completes
- [x] Confirmed no compilation errors or warnings

Closes #7