### PR TITLE
Fix reflexive pronoun duplication in AI-generated exercises

### DIFF
--- a/src/app/api/generate-exercise-set/route.ts
+++ b/src/app/api/generate-exercise-set/route.ts
@@ -270,6 +270,12 @@ Key requirements:
 - Maintain appropriate ${cefrLevel} difficulty level
 - Set "isPlural" to true when the correct answer requires a plural form
 
+CRITICAL: Avoid reflexive pronoun duplication!
+- If a reflexive pronoun (se/si) appears in the visible text, do NOT include it in the expected answer
+- For reflexive verbs, either put the reflexive pronoun in the blank OR in the visible text, never both
+- Example: "Ana _____ (pripremiti se)" expects "se priprema" OR "Ana se _____ (pripremiti)" expects "priprema"
+- Never create: "Ana se _____ (pripremiti se)" expecting "se priprema" - this duplicates "se"
+
 Return JSON in this exact format:
 {
   "id": "generated-uuid",
@@ -334,6 +340,12 @@ Key requirements:
 - Include a variety of contexts (daily activities, past events, future plans)
 - Provide clear explanations about tense and person
 - Maintain appropriate ${cefrLevel} difficulty level
+
+CRITICAL: Avoid reflexive pronoun duplication!
+- If a reflexive pronoun (se/si) appears in the visible text, do NOT include it in the expected answer
+- For reflexive verbs, either put the reflexive pronoun in the blank OR in the visible text, never both
+- Example: "Ana _____ (pripremiti se)" expects "se priprema" OR "Ana se _____ (pripremiti)" expects "priprema"
+- Never create: "Ana se _____ (pripremiti se)" expecting "se priprema" - this duplicates "se"
 
 Return JSON in this exact format:
 {
@@ -444,6 +456,12 @@ Key requirements:
 - Maintain appropriate ${cefrLevel} difficulty level
 - Set "isPlural" to true when the correct answer requires a plural form
 
+CRITICAL: Avoid reflexive pronoun duplication!
+- If a reflexive pronoun (se/si) appears in the visible text, do NOT include it in the expected answer
+- For reflexive verbs, either put the reflexive pronoun in the blank OR in the visible text, never both
+- Example: "Ana _____ (pripremiti se)" expects "se priprema" OR "Ana se _____ (pripremiti)" expects "priprema"
+- Never create: "Ana se _____ (pripremiti se)" expecting "se priprema" - this duplicates "se"
+
 Return JSON in this exact format:
 {
   "id": "generated-uuid",
@@ -508,6 +526,12 @@ Key requirements:
 - Include a variety of contexts (daily activities, past events, future plans)
 - Provide clear explanations about tense and person
 - Maintain appropriate ${cefrLevel} difficulty level
+
+CRITICAL: Avoid reflexive pronoun duplication!
+- If a reflexive pronoun (se/si) appears in the visible text, do NOT include it in the expected answer
+- For reflexive verbs, either put the reflexive pronoun in the blank OR in the visible text, never both
+- Example: "Ana _____ (pripremiti se)" expects "se priprema" OR "Ana se _____ (pripremiti)" expects "priprema"
+- Never create: "Ana se _____ (pripremiti se)" expecting "se priprema" - this duplicates "se"
 
 Return JSON in this exact format:
 {

--- a/src/components/ParagraphExercise.tsx
+++ b/src/components/ParagraphExercise.tsx
@@ -71,7 +71,13 @@ export function ParagraphExercise({ exerciseSet, exerciseType, onComplete, title
 
         if (isStaticExercise(question.id)) {
           // Handle static exercise locally
-          const result = createExerciseResult(question.id, userAnswer, question.correctAnswer, question.explanation);
+          const result = createExerciseResult(
+            question.id,
+            userAnswer,
+            question.correctAnswer,
+            question.explanation
+          );
+          
           newResults[question.id] = result;
           dispatch({ type: "ADD_RESULT", payload: result });
         } else {


### PR DESCRIPTION
## Summary

This PR fixes issue #23 where reflexive pronouns (like "se") appear both in the visible text and are still expected in the user's answer, causing confusion and incorrect validation.

## Solution

Instead of implementing complex code-based validation logic, this takes a **prompt-based approach** that prevents the issue at the source by instructing the AI not to generate problematic exercises in the first place.

## Changes Made

- **Updated AI prompts** in `src/app/api/generate-exercise-set/route.ts` for both OpenAI and Anthropic providers
- **Added specific instructions** to prevent reflexive pronoun duplication:
  - If a reflexive pronoun (se/si) appears in visible text, don't include it in the expected answer
  - For reflexive verbs, put the pronoun either in the blank OR in the visible text, never both
  - Provided clear examples of correct vs incorrect patterns

## Example

**❌ Before (problematic):**
```
Ana se _____ (pripremiti se)  // expects "se priprema" - duplicates "se"
```

**✅ After (fixed):**
```
Ana _____ (pripremiti se)     // expects "se priprema" - OR
Ana se _____ (pripremiti)     // expects "priprema"
```

## Benefits

- **Simple and maintainable** - just prompt changes, no complex validation logic
- **Addresses root cause** - prevents bad exercises from being generated
- **Robust** - works for all exercise types (verb tenses, verb aspect, etc.)
- **Clean codebase** - no additional complexity in validation logic

## Testing

- ✅ Build passes successfully
- ✅ No breaking changes to existing functionality  
- ✅ All existing validation logic remains intact

Fixes #23